### PR TITLE
fix(siphash): widen input length counter

### DIFF
--- a/include/siphash-hpp/siphash.hpp
+++ b/include/siphash-hpp/siphash.hpp
@@ -67,8 +67,8 @@ namespace siphash_hpp {
     class SipHash {
     private:
 		size_t c, d, index;
-		uint64_t v0, v1, v2, v3, m;
-		uint8_t input_len;
+                uint64_t v0, v1, v2, v3, m;
+                uint64_t input_len;
 
         template<class T>
         inline const uint64_t read8(const T &p, const size_t o = 0) noexcept {
@@ -221,7 +221,7 @@ namespace siphash_hpp {
 
         const uint64_t digest() noexcept {
             while (index < 7) ++index;
-            m |= ((uint64_t) input_len) << (index * 8);
+            m |= (input_len << (index * 8));
             digest_block();
             v2 ^= 0xff;
             for(size_t i = 0; i < d; ++i){

--- a/tests/siphash_tests.cpp
+++ b/tests/siphash_tests.cpp
@@ -53,3 +53,12 @@ TEST(SipHash, LongMessageArrayKey) {
         char(0x8A), char(0x8B), char(0x8C), char(0x8D), char(0x8E)};
     EXPECT_EQ(10101490021502548721ULL, siphash_hpp::siphash_2_4(data, key));
 }
+
+TEST(SipHash, MessageLongerThan255Bytes) {
+    char key[16];
+    for (int i = 0; i < 16; ++i) key[i] = static_cast<char>(i);
+    std::string data;
+    data.reserve(300);
+    for (int i = 0; i < 300; ++i) data.push_back(static_cast<char>(i));
+    EXPECT_EQ(5407540081291524153ULL, siphash_hpp::siphash_2_4(data, key));
+}


### PR DESCRIPTION
## Summary
- track full message length with uint64_t and update digest handling
- test hashing data longer than 255 bytes

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b90fb8ee18832cb277d32a20babc96