### PR TITLE
refactor: rename targets and namespace to siphash_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,43 @@
 cmake_minimum_required(VERSION 3.16)
-project(siphash-hpp VERSION 1.0 LANGUAGES CXX)
+project(siphash_cpp VERSION 1.0.0 LANGUAGES CXX)
 
 option(BUILD_TESTING "Build tests" ON)
 option(BUILD_EXAMPLES "Build examples" OFF)
 
-add_library(siphash_hpp INTERFACE)
-target_include_directories(siphash_hpp INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/siphash-hpp>
-    $<INSTALL_INTERFACE:include/siphash-hpp>)
-target_compile_features(siphash_hpp INTERFACE cxx_std_11)
+add_library(siphash_cpp INTERFACE)
+target_include_directories(siphash_cpp INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/siphash_cpp>
+    $<INSTALL_INTERFACE:include/siphash_cpp>)
+target_compile_features(siphash_cpp INTERFACE cxx_std_11)
 
 include(CMakePackageConfigHelpers)
 
-install(TARGETS siphash_hpp EXPORT siphash-hpp-targets)
-install(DIRECTORY include/siphash-hpp/ DESTINATION include/siphash-hpp)
+install(TARGETS siphash_cpp EXPORT siphash_cpp-targets)
+install(DIRECTORY include/siphash_cpp/ DESTINATION include/siphash_cpp)
 
-install(EXPORT siphash-hpp-targets
-  FILE siphash-hpp-targets.cmake
-  NAMESPACE siphash_hpp::
-  DESTINATION lib/cmake/siphash-hpp)
+install(EXPORT siphash_cpp-targets
+  FILE siphash_cpp-targets.cmake
+  NAMESPACE siphash_cpp::
+  DESTINATION lib/cmake/siphash_cpp)
 
 configure_package_config_file(
-  cmake/siphash-hpp-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config.cmake
-  INSTALL_DESTINATION lib/cmake/siphash-hpp)
+  cmake/siphash_cpp-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash_cpp-config.cmake
+  INSTALL_DESTINATION lib/cmake/siphash_cpp)
 
 write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config-version.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash_cpp-config-version.cmake
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion)
 
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config-version.cmake
-  DESTINATION lib/cmake/siphash-hpp)
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash_cpp-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash_cpp-config-version.cmake
+  DESTINATION lib/cmake/siphash_cpp)
 
 if(BUILD_EXAMPLES)
   add_executable(siphash_example examples/basic.cpp)
-  target_link_libraries(siphash_example PRIVATE siphash_hpp)
+  target_link_libraries(siphash_example PRIVATE siphash_cpp)
 endif()
 
 if(BUILD_TESTING)
@@ -49,6 +49,6 @@ if(BUILD_TESTING)
   FetchContent_MakeAvailable(googletest)
 
   add_executable(siphash_tests tests/siphash_tests.cpp)
-  target_link_libraries(siphash_tests PRIVATE siphash_hpp gtest_main)
+    target_link_libraries(siphash_tests PRIVATE siphash_cpp gtest_main)
   add_test(NAME siphash_tests COMMAND siphash_tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# siphash-hpp
+# siphash_cpp
 
-[![Linux](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Linux.yml/badge.svg)](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Linux.yml)
-[![Win](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Win.yml/badge.svg)](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Win.yml)
+[![Linux](https://github.com/NewYaroslav/siphash_cpp/actions/workflows/CI-Linux.yml/badge.svg)](https://github.com/NewYaroslav/siphash_cpp/actions/workflows/CI-Linux.yml)
+[![Win](https://github.com/NewYaroslav/siphash_cpp/actions/workflows/CI-Win.yml/badge.svg)](https://github.com/NewYaroslav/siphash_cpp/actions/workflows/CI-Win.yml)
 
 [SipHash](https://en.wikipedia.org/wiki/SipHash) header only C ++ library.
 
@@ -17,11 +17,11 @@ Example:
 std::array<char, 16> key = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
 std::string data("hello");
 
-std::cout << "SipHash-2-4 for 'hello': " << siphash_hpp::siphash_2_4(data, key) << std::endl;
-std::cout << "SipHash-4-8 for 'hello': " << siphash_hpp::siphash_4_8(data, key) << std::endl;
-std::cout << "SipHash-4-8 for 'hello': " << siphash_hpp::siphash(data, key, 4, 8) << std::endl;
+std::cout << "SipHash-2-4 for 'hello': " << siphash_cpp::siphash_2_4(data, key) << std::endl;
+std::cout << "SipHash-4-8 for 'hello': " << siphash_cpp::siphash_4_8(data, key) << std::endl;
+std::cout << "SipHash-4-8 for 'hello': " << siphash_cpp::siphash(data, key, 4, 8) << std::endl;
 
-siphash_hpp::SipHash siphash;
+siphash_cpp::SipHash siphash;
 siphash.init(key, 2, 4);
 std::cout << "SipHash-2-4 for 'hello': " << siphash.update(data).digest() << std::endl;
 ```

--- a/cmake/siphash-hpp-config.cmake.in
+++ b/cmake/siphash-hpp-config.cmake.in
@@ -1,3 +1,0 @@
-@PACKAGE_INIT@
-
-include("${CMAKE_CURRENT_LIST_DIR}/siphash-hpp-targets.cmake")

--- a/cmake/siphash_cpp-config.cmake.in
+++ b/cmake/siphash_cpp-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/siphash_cpp-targets.cmake")

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -4,18 +4,18 @@
 
 #include "siphash.hpp"
 
-// Demonstrates hashing messages with siphash-hpp.
+// Demonstrates hashing messages with siphash_cpp.
 int main() {
     // 16-byte secret key. Replace with a random key in real applications.
     const std::array<char, 16> key{'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
     const std::string msg = "hello";
 
     // Convenience function for SipHash-2-4.
-    const uint64_t hash_2_4 = siphash_hpp::siphash_2_4(msg, key);
+    const uint64_t hash_2_4 = siphash_cpp::siphash_2_4(msg, key);
     std::cout << "SipHash-2-4(\"" << msg << "\") = " << hash_2_4 << std::endl;
 
     // Using the SipHash class for custom parameters.
-    siphash_hpp::SipHash hasher;
+    siphash_cpp::SipHash hasher;
     hasher.init(key, 4, 8); // c = 4, d = 8
     const uint64_t hash_4_8 = hasher.update(msg).digest();
     std::cout << "SipHash-4-8(\"" << msg << "\") = " << hash_4_8 << std::endl;

--- a/include/siphash_cpp/siphash.hpp
+++ b/include/siphash_cpp/siphash.hpp
@@ -24,7 +24,7 @@ namespace std {
 }
 #endif
 
-namespace siphash_hpp {
+namespace siphash_cpp {
 
     template<typename T, typename = void>
     struct has_static_size : std::false_type {};

--- a/tests/siphash_tests.cpp
+++ b/tests/siphash_tests.cpp
@@ -14,15 +14,15 @@ TEST(SipHash, KnownValues) {
     std::array<char, 16> key = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
     std::string data = "hello";
 
-    EXPECT_EQ(4402678656023170274ULL, siphash_hpp::siphash_2_4(data, key));
-    EXPECT_EQ(14986662229302055855ULL, siphash_hpp::siphash_4_8(data, key));
+    EXPECT_EQ(4402678656023170274ULL, siphash_cpp::siphash_2_4(data, key));
+    EXPECT_EQ(14986662229302055855ULL, siphash_cpp::siphash_4_8(data, key));
 }
 
 TEST(SipHash, EmptyMessageArrayKey) {
     char key[16];
     for (int i = 0; i < 16; ++i) key[i] = static_cast<char>(i);
     std::string data;
-    EXPECT_EQ(8246050544436514353ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(8246050544436514353ULL, siphash_cpp::siphash_2_4(data, key));
 }
 
 TEST(SipHash, SevenByteMessagePointerKey) {
@@ -32,7 +32,7 @@ TEST(SipHash, SevenByteMessagePointerKey) {
     std::string data = {
         char(0x80), char(0x81), char(0x82),
         char(0x83), char(0x84), char(0x85), char(0x86)};
-    EXPECT_EQ(3571205124105766914ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(3571205124105766914ULL, siphash_cpp::siphash_2_4(data, key));
 }
 
 TEST(SipHash, EightByteMessageStdArrayKey) {
@@ -41,7 +41,7 @@ TEST(SipHash, EightByteMessageStdArrayKey) {
     std::string data = {
         char(0x80), char(0x81), char(0x82), char(0x83),
         char(0x84), char(0x85), char(0x86), char(0x87)};
-    EXPECT_EQ(15639825339957833178ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(15639825339957833178ULL, siphash_cpp::siphash_2_4(data, key));
 }
 
 TEST(SipHash, LongMessageArrayKey) {
@@ -51,7 +51,7 @@ TEST(SipHash, LongMessageArrayKey) {
         char(0x80), char(0x81), char(0x82), char(0x83), char(0x84),
         char(0x85), char(0x86), char(0x87), char(0x88), char(0x89),
         char(0x8A), char(0x8B), char(0x8C), char(0x8D), char(0x8E)};
-    EXPECT_EQ(10101490021502548721ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(10101490021502548721ULL, siphash_cpp::siphash_2_4(data, key));
 }
 
 TEST(SipHash, MessageLongerThan255Bytes) {
@@ -60,5 +60,5 @@ TEST(SipHash, MessageLongerThan255Bytes) {
     std::string data;
     data.reserve(300);
     for (int i = 0; i < 300; ++i) data.push_back(static_cast<char>(i));
-    EXPECT_EQ(5407540081291524153ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(5407540081291524153ULL, siphash_cpp::siphash_2_4(data, key));
 }


### PR DESCRIPTION
## Summary
- rename project and targets from siphash_hpp to siphash_cpp
- adjust include directories and CMake export files
- update namespace and usages to siphash_cpp
- set project version to 1.0.0 and refresh README

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b985c73324832c97eb88bccb022576