### PR TITLE
Add vcpkg manifest and usage docs

### DIFF
--- a/.github/workflows/CI-Linux.yml
+++ b/.github/workflows/CI-Linux.yml
@@ -24,3 +24,17 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y cmake
           CXX_STANDARD=${{ matrix.std }} ./scripts/run_tests.sh
+  Tests-Linux-vcpkg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cmake and vcpkg
+        run: |
+          sudo apt-get update && sudo apt-get install -y cmake
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+      - name: Build and Run Tests with vcpkg
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+        run: |
+          CXX_STANDARD=17 ./scripts/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ siphash.init(key, 2, 4);
 std::cout << "SipHash-2-4 for 'hello': " << siphash.update(data).digest() << std::endl;
 ```
 
+## vcpkg
+
+This library can be installed with [vcpkg](https://github.com/microsoft/vcpkg):
+
+```sh
+vcpkg install siphash-cpp
+```
+
+After installation, a CMake project may use:
+
+```cmake
+find_package(siphash_cpp CONFIG REQUIRED)
+target_link_libraries(your_app PRIVATE siphash_cpp::siphash_cpp)
+```
+
+To verify the build with vcpkg, run:
+
+```sh
+VCPKG_ROOT=/path/to/vcpkg ./scripts/run_tests.sh
+```
+
 
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,7 +5,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="$ROOT_DIR/build"
 
 rm -rf "$BUILD_DIR"
-cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=${CXX_STANDARD:-17}
+cmake_args=(-S "$ROOT_DIR" -B "$BUILD_DIR" -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=${CXX_STANDARD:-17})
+if [[ -n "${VCPKG_ROOT:-}" ]]; then
+  cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+fi
+cmake "${cmake_args[@]}"
 cmake --build "$BUILD_DIR" --config Release
 cd "$BUILD_DIR"
 ctest --output-on-failure

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "siphash-cpp",
+  "version": "1.0.0",
+  "description": "SipHash header-only C++ library",
+  "license": "CC0-1.0",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- add vcpkg manifest and CI job
- allow run_tests.sh to use vcpkg toolchain
- document vcpkg usage and verification

## Testing
- `CXX_STANDARD=17 ./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b98ee76080832caa5c3114142da0c7