### PR TITLE
docs: add task for FetchContent timestamp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- [ ] Configure `FetchContent` to use `DOWNLOAD_EXTRACT_TIMESTAMP` or set policy `CMP0135` to avoid CMake developer warnings during builds.


### PR DESCRIPTION
## Summary
- add task to address CMake FetchContent timestamp warning

## Testing
- `./scripts/run_tests.sh`
- `/tmp/vcpkg/vcpkg install --triplet x64-linux`


------
https://chatgpt.com/codex/tasks/task_e_68b9b3673dfc832c943d54f2b94c17d3